### PR TITLE
fix: review page

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boj-addon-google-extension",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "백준 문제풀이 애드온</br></br>\r 백준 문제풀이 에드온은 백준 온라인 저지 사이트에서 **바로 문제를 풀 수 있게 도와주는 크롬 익스텐션**입니다.</br></br>\r 현재는 **Node.js, Python, C++**로만 문제풀이가 가능하며, 추후 다른 언어 문제풀이도 추가할 예정입니다.</br></br>\r 추가적인 요청 사항을 **이슈**에 남겨주시면 추가로 수정하겠습니다. </br></br>",
   "type": "module",
   "scripts": {

--- a/extension/src/App.tsx
+++ b/extension/src/App.tsx
@@ -5,6 +5,7 @@ import { editorModeState, serverStatusState } from "./utils/atom";
 import TestCase from "./components/TestCase";
 import { BOJProblem } from "./components/BOJProblem";
 import { path } from "./utils/path";
+import { bojStorage } from "./utils/bojStorage";
 
 interface AppProps{
   problemId : string | null;
@@ -29,7 +30,7 @@ export function App({ problemId }:AppProps) {
     const handleClick = () => {
       const updatedMode = !editorMode
       setEditorMode(updatedMode)
-      localStorage.setItem('editor-mode', `${updatedMode}`);
+      bojStorage.setItem('editor-mode', `${updatedMode}`);
     };
 
     if (legend) legend.addEventListener('click', handleClick);

--- a/extension/src/components/CodeResult.tsx
+++ b/extension/src/components/CodeResult.tsx
@@ -5,6 +5,8 @@ import { editorState, langState, serverStatusState }  from "../utils/atom";
 import { path } from "../utils/path";
 import { Result, SupportedLang } from "../types/types";
 import { CodeResultBlock } from "./CodeResultBlock";
+import { bojStorage } from "../utils/bojStorage";
+import { getLangCode } from "../utils/lang";
 
 
 interface CodeResultProps{
@@ -44,7 +46,7 @@ export const CodeResult = ({ clickEvent, dragEvent, resizeY, results }:CodeResul
         <div className="code_nav">
           <SubmitButton/>
           <button onClick={clickEvent} className="code_button" disabled={disableRunCode}>
-            실행(ALT(⌘)+ENTER)
+            실행(ALT(⌥)+ENTER)
           </button>
         </div>
       </div>
@@ -60,16 +62,7 @@ function SubmitButton() {
   const [lang] = useRecoilState(langState);
   const editor = useRecoilValue(editorState);
 
-  const getLangCode = (lang:SupportedLang) => {
-    if (lang === 'cpp') return 84;
-    if (lang === 'python') return 28;
-    if (lang === 'nodejs') return 17;
-    if (lang === "csharp") return 86;
-    if (lang === 'rust') return 94;
-    if (lang === 'java') return 93;
 
-    return 84;
-  };
   function getValidCsrfKey() {
     const inputs = document.querySelectorAll('input[name="csrf_key"]');
     const validInput = Array.from(inputs).find((input): input is HTMLInputElement =>
@@ -80,7 +73,9 @@ function SubmitButton() {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     const form = e.target as HTMLFormElement;
     if(editor)form.source.value = editor.getValue();
-    form.language.value = getLangCode(lang);
+    form.language.value = bojStorage.isValidPage()
+                            ? getLangCode(lang) 
+                            : (document.querySelector("select#language") as HTMLSelectElement).value;
   };
   if(!isSubmitPage) return null;
   return (

--- a/extension/src/components/InputMenu.css
+++ b/extension/src/components/InputMenu.css
@@ -23,6 +23,10 @@
     overflow: hidden;
     text-overflow: ellipsis;  
   }
+  .lang-popup:disabled{
+    opacity: 0.5; 
+    pointer-events: none;
+  }
   .connect-error{
     color:darkgray;
   }

--- a/extension/src/const/sampleCode.tsx
+++ b/extension/src/const/sampleCode.tsx
@@ -83,5 +83,35 @@ export const sampleCode = {
         code: 'using System;\nclass Program {\n    static void Main() {\n        int n = int.Parse(Console.ReadLine());\n        int[] arr = new int[n];\n        for (int i = 0; i < n; i++) {\n            arr[i] = int.Parse(Console.ReadLine());\n        }\n    }\n}',
       },
     ],
+    rust: [
+      { button: "입력값 없음", code: "" },
+      {
+        button: "input\n\n입력 값 1개",
+        code: 'use std::io;\nfn main() {\n    let mut input = String::new();\n    io::stdin().read_line(&mut input).unwrap();\n    let input = input.trim();\n    println!("{}", input);\n}',
+      },
+      {
+        button: "arr[0], arr[1], ...arr[n]\n\n빈칸을 두고 값 정렬",
+        code: 'use std::io;\nfn main() {\n    let mut input = String::new();\n    io::stdin().read_line(&mut input).unwrap();\n    let arr: Vec<i32> = input.trim().split_whitespace()\n        .map(|s| s.parse().unwrap()).collect();\n    println!("{:?}", arr);\n}',
+      },
+      {
+        button: "N\narr[0]\narr[1]\n...\narr[n]\n\n첫째 줄에 N, 두 번째줄부터 값 정렬",
+        code: 'use std::io::{self, BufRead};\nfn main() {\n    let stdin = io::stdin();\n    let mut lines = stdin.lock().lines();\n    let n: usize = lines.next().unwrap().unwrap().trim().parse().unwrap();\n    let mut arr = Vec::new();\n    for _ in 0..n {\n        let val: i32 = lines.next().unwrap().unwrap().trim().parse().unwrap();\n        arr.push(val);\n    }\n    println!("{:?}", arr);\n}',
+      },
+    ],
+    java: [
+      { button: "입력값 없음", code: "" },
+      {
+        button: "input\n\n입력 값 1개",
+        code: 'import java.util.Scanner;\nclass Main {\n    public static void main(String[] args) {\n        Scanner sc = new Scanner(System.in);\n        String input = sc.nextLine();\n        System.out.println(input);\n    }\n}',
+      },
+      {
+        button: "arr[0], arr[1], ...arr[n]\n\n빈칸을 두고 정수 정렬",
+        code: 'import java.util.*;\nclass Main {\n    public static void main(String[] args) {\n        Scanner sc = new Scanner(System.in);\n        String[] tokens = sc.nextLine().split(" ");\n        int[] arr = Arrays.stream(tokens).mapToInt(Integer::parseInt).toArray();\n        System.out.println(Arrays.toString(arr));\n    }\n}',
+      },
+      {
+        button: "N\narr[0]\narr[1]\n...\narr[n]\n\n첫째 줄에 N, 두 번째줄부터 값 정렬",
+        code: 'import java.util.*;\nclass Main {\n    public static void main(String[] args) {\n        Scanner sc = new Scanner(System.in);\n        int n = Integer.parseInt(sc.nextLine());\n        int[] arr = new int[n];\n        for (int i = 0; i < n; i++) {\n            arr[i] = Integer.parseInt(sc.nextLine());\n        }\n        System.out.println(Arrays.toString(arr));\n    }\n}',
+      },
+    ],
   };
   

--- a/extension/src/types/types.ts
+++ b/extension/src/types/types.ts
@@ -1,3 +1,3 @@
-export type SupportedLang = "nodejs" | "python" | "cpp" | "csharp";
+export type SupportedLang = "nodejs" | "python" | "cpp" | "csharp" | "rust" | "java";
 export type Result = { message?: string; error?: string; input?: string, output?:string, expected?:string};
 export type TestCode = { input:string, output:string};

--- a/extension/src/utils/atom.ts
+++ b/extension/src/utils/atom.ts
@@ -1,6 +1,7 @@
 import { atom } from "recoil";
 import type { editor } from "monaco-editor";
 import { SupportedLang, TestCode } from "../types/types";
+import { bojStorage } from "./bojStorage";
 
 
 const exampleNumberState = atom({
@@ -21,7 +22,7 @@ const editorState = atom<editor.IStandaloneCodeEditor | null>({
 const editorModeState = atom({
   key: "editorModeState",
   default: document.querySelector(".loginbar.pull-right")?.textContent?.includes("로그아웃")
-    ?(localStorage.getItem('editor-mode')|| true)==='true'
+    ?(bojStorage.getItem('editor-mode')|| true)==='true'
     : false,
 });
 

--- a/extension/src/utils/bojStorage.ts
+++ b/extension/src/utils/bojStorage.ts
@@ -1,0 +1,27 @@
+import { path } from "./path";
+
+class BOJStorage{
+    public isValidPage(){
+        const pathname = window.location.pathname;
+        return /^\/(submit|problem)\/\d+$/.test(pathname);
+    }
+    public setItem(key:string, value:string){
+        if(!this.isValidPage()) return
+        return localStorage.setItem(key, value)
+    }
+    public getInitialCode(){
+        return (this.isValidPage() 
+            ? (this.getItem(path.getProblemPathByNumber())) 
+            : this.getReviewSource()) ?? ""
+    }
+    public getReviewSource(){
+        const sourceElement = document.getElementById("source")
+        return sourceElement? sourceElement.textContent : ""
+    }
+    public getItem(key:string, ){
+        if(!this.isValidPage()) return null
+        return localStorage.getItem(key)
+    }
+}
+
+export const bojStorage = new BOJStorage()

--- a/extension/src/utils/lang.ts
+++ b/extension/src/utils/lang.ts
@@ -3,3 +3,23 @@ import { SupportedLang } from "../types/types";
 export const isSupportedLang = (value: string|null): value is SupportedLang => {
     return ["nodejs", "python", "cpp", "csharp"].includes(value||'');
 };
+const langCodeMap: Record<SupportedLang, string> = {
+    cpp: "84",
+    python: "28",
+    nodejs: "17",
+    csharp: "86",
+    rust: "94",
+    java: "93",
+  };
+  
+const codeLangMap = Object.fromEntries(
+    Object.entries(langCodeMap).map(([lang, code]) => [code, lang])
+) as Record<string, SupportedLang>;
+
+export const getLangCode = (lang: string): string => {
+    return langCodeMap[lang as SupportedLang] ?? "84";
+};
+
+export const getLangByCode = (code: string): SupportedLang => {
+    return codeLangMap[code] ?? "nodejs";
+};

--- a/extension/src/utils/path.ts
+++ b/extension/src/utils/path.ts
@@ -1,8 +1,8 @@
 class Path{
     public problemId(){
         const pathname = window.location.pathname;
-        const match = pathname.match(/(\d+)$/);
-        return match ? match[1] : null;
+        const match = pathname.match(/^\/(submit|problem)\/(\d+)(?:\/(\d+))?/);
+        return match ? match[2] : null;
     }
     public getProblemPathByNumber(){
         return `/problem/${this.problemId()}`

--- a/extension/src/utils/theme.ts
+++ b/extension/src/utils/theme.ts
@@ -1,4 +1,5 @@
 import * as monaco from "monaco-editor";
+import { bojStorage } from "./bojStorage";
 
 const themeObject = {
   "vs-dark": {
@@ -38,7 +39,7 @@ const themeObject = {
 };
 
 export const changeThemeProperty = () => {
-    const mode = (localStorage.getItem("mode") ?? "vs-dark") as keyof typeof themeObject;
+    const mode = (bojStorage.getItem("mode") ?? "vs-dark") as keyof typeof themeObject;
     const theme = themeObject[mode];
   
     Object.entries(theme.colorset).forEach(([key, value]) => {
@@ -49,17 +50,17 @@ export const changeThemeProperty = () => {
   };
   
   export const setTheme = () => {
-    if (!localStorage.getItem("mode")) {
-      localStorage.setItem("mode", "vs-dark");
+    if (!bojStorage.getItem("mode")) {
+      bojStorage.setItem("mode", "vs-dark");
     }
     return changeThemeProperty();
   };
   
   export const changeTheme = () => {
-    const mode = (localStorage.getItem("mode") ?? "vs-dark") as keyof typeof themeObject;
+    const mode = (bojStorage.getItem("mode") ?? "vs-dark") as keyof typeof themeObject;
     const theme = themeObject[mode];
   
     monaco.editor.setTheme(theme.to);
-    localStorage.setItem("mode", theme.to);
+    bojStorage.setItem("mode", theme.to);
     changeThemeProperty();
   };  


### PR DESCRIPTION
## 제출 코드 수정 시 기존 코드가 불러와지지 않는 문제 해결

### 📌 이슈
- 제출된 코드의 **수정 버튼 클릭 시 기존 코드가 불러와지지 않는 문제**가 발생했습니다.

### 🔍 원인
- 원래는 `submit/문제이름` 경로에서만 코드 에디터가 동작하도록 되어 있었으나,  
  `submit/문제이름/제출한문제ID` 형식의 경로도 존재하면서 **라우팅 충돌**이 발생했습니다.

### 🛠️ 해결 방법
- `submit/문제이름/숫자` 형식의 경로를 식별하여,  
  기존의 `problem/문제이름`, `submit/문제이름`과는 **다른 로직이 동작**하도록 처리했습니다.
- 해당 경로에 이미 미리 불러와진 `source(code)`가 존재할 경우,  
  이를 코드 에디터에 자동으로 띄워 수정 및 재실행, 재제출이 가능하도록 구현했습니다.

### ⚠️ 참고 사항
- 현재는 **모든 언어에 대해 수정/재제출이 가능한 상태는 아니며**,  
  **특정 언어로 고정**하여만 수정 및 재제출이 가능하도록 제한해두었습니다.
- 현재 수정사항은 v2.0.4에 적용될 예정입니다. 
- 작성일자인 2025.4.8 1:24PM 현재 v2.0.2가 적용중이며, v2.0.3은 스토어 검토중입니다.

Closes #6 
