### PR TITLE
fix: powershell error

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -7,6 +7,7 @@ import path from "path";
 import os from "os";
 import { load } from "cheerio";
 import { removeTempDir } from "./utils/clean";
+import { platform } from "os";
 const PORT = 100;
 
 interface RequestBody {
@@ -32,11 +33,13 @@ const executableMap: Record<string, string> = {
 
 // 실행 파일이 설치되어 있는지 확인
 async function isExecutableInstalled(command: string): Promise<boolean> {
-    return new Promise((resolve) => {
-        exec(`which ${command}`, (error, stdout) => {
-            resolve(Boolean(stdout.trim()) && !error);
-        });
-    });
+  const cmd = platform() === "win32" ? `where ${command}` : `which ${command}`;
+  return new Promise((resolve) => {
+      exec(cmd, (error, stdout) => {
+          console.error(error);
+          resolve(Boolean(stdout.trim()) && !error);
+      });
+  });
 }
 
 // C++ 코드 컴파일 및 실행


### PR DESCRIPTION
## 🛠 PowerShell에서 실행되지 않던 문제 수정

### 문제 원인
`which` 명령어를 사용해 커맨드 존재 여부를 확인하고 있었는데, 이는 macOS나 Linux와 같은 bash 환경에서는 정상 작동하지만, Windows의 PowerShell이나 CMD에서는 인식되지 않음.

### 해결 방법
- 운영체제에 따라 적절한 명령어(`which` 또는 `where`)를 사용하도록 수정
- `process.platform`을 기반으로 분기 처리
- Windows 환경의 Git Bash에서도 `where` 명령어가 정상 작동하는지 확인함

### 테스트 환경
- macOS (bash/zsh): ✅
- Ubuntu (bash): ✅
- Windows PowerShell: ✅
- Windows CMD: ✅
- Windows Git Bash: ✅


### 참고
이번 boj-server 업데이트는 c# 코드가 포함되어 있기 때문에, v2.0.3가 업데이트 된 이후에 바로 업데이트 하겠습니다 : )

Closes #4 