### PR TITLE
fix: reCAPTCHA

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "BOJ Addon",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "BOJ Addon",
   "author": "Namheon Baek",
   "content_scripts": [

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boj-addon-google-extension",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "백준 문제풀이 애드온</br></br>\r 백준 문제풀이 에드온은 백준 온라인 저지 사이트에서 **바로 문제를 풀 수 있게 도와주는 크롬 익스텐션**입니다.</br></br>\r 현재는 **Node.js, Python, C++**로만 문제풀이가 가능하며, 추후 다른 언어 문제풀이도 추가할 예정입니다.</br></br>\r 추가적인 요청 사항을 **이슈**에 남겨주시면 추가로 수정하겠습니다. </br></br>",
   "type": "module",
   "scripts": {

--- a/extension/src/components/CodeResult.tsx
+++ b/extension/src/components/CodeResult.tsx
@@ -104,13 +104,30 @@ function SubmitButton() {
     );
     return validInput?.value || null;
   }
+  function getGRecaptchaResponse(){
+    const wrapper = document.getElementById("g-recaptcha-response-100000") as HTMLTextAreaElement;
+    return wrapper?.value || null;
+  }
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     const form = e.target as HTMLFormElement;
+    form["g-recaptcha-response"].value = getGRecaptchaResponse();
     if(editor)form.source.value = editor.getValue();
     form.language.value = bojStorage.isValidPage()
                             ? getLangCode(lang) 
                             : (document.querySelector("select#language") as HTMLSelectElement).value;
+    console.log(form)
   };
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = 'http://localhost:100/enterprise.js';
+    script.async = true;
+    document.body.appendChild(script);
+
+    // 컴포넌트 언마운트 시 스크립트 제거
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
   if(!isSubmitPage) return null;
   return (
     <form
@@ -118,7 +135,8 @@ function SubmitButton() {
       action=""
       method="POST"
       onSubmit={handleSubmit}
-    >
+    >                      
+      <input type="hidden" name="g-recaptcha-response" value={getGRecaptchaResponse()||""} />
       <input type="hidden" name="problem_id" value={problemId||""} />
       <input type="hidden" name="language" value="" />
       <input type="hidden" name="code_open" value="open" />

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boj-server",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "description": "A simple server to execute Python, C++, and Node.js code with input/output handling.",
   "main": "dist/main.js",
   "bin": "./dist/main.js",

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -190,6 +190,21 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
     }
 
     if (req.method === "GET") {
+        if(req.url =="/enterprise.js"){
+          const jsCode = `
+            const siteKey = "6Le_rx4rAAAAAATDXRag3GgpO641c5wodH30zQh1";
+            if (typeof window.grecaptcha !== 'undefined' && typeof window.grecaptcha.enterprise !== 'undefined') {
+              window.grecaptcha.enterprise.execute(siteKey, { action: 'submit' })
+            } else {
+              console.warn('grecaptcha가 아직 로드되지 않았습니다. 500ms 후에 다시 시도합니다.');
+              setTimeout(function() {
+                executeRecaptcha(siteKey);
+              }, 500);
+            }`
+          res.setHeader('Content-Type', 'application/javascript');
+          res.end(jsCode);
+          return;
+        }
         if(req.url === "/healthy"){
             res.writeHead(200, { "Content-Type": "application/json" });
             res.end(JSON.stringify({ status: "OK", supported_language: ["python", "cpp", "nodejs", "csharp"] }));


### PR DESCRIPTION
## 변경된 해결 방법:
초기에는 MonacoEditor를 CodeMirror로 교체하여 reCAPTCHA 문제를 해결하려 했지만, 코드 제출이 안되는 사항은 매우 긴급한 사항이기 때문에 서버에 별도로 JavaScript 파일을 inject하여 reCAPTCHA를 실행하고, 그 결과 값을 코드 제출 시 사용하는 방식으로 문제를 해결했습니다.

## 적용된 주요 내용:

서버 측에서 reCAPTCHA 실행 스크립트를 별도로 삽입하고, 이를 통해 정상적으로 reCAPTCHA 값을 얻고 코드를 post로 같이 보냅니다.

close #10 